### PR TITLE
fix: deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,11 @@ Take a look at these existing plugins for how that can be done very simply:
 * [nativescript-cardview](https://github.com/bradmartin/nativescript-cardview/tree/master/platforms)
 * [nativescript-floatingactionbutton](https://github.com/bradmartin/nativescript-floatingactionbutton/tree/master/platforms)
 
+### Clean plugin and demo files
+
+Sometimes you may need to wipe away the `node_modules` and `demo/platforms` folders to reinstall them fresh.
+
+1. Run `npm run clean` to wipe those clean then you can can run `npm i` to install fresh dependencies.
 
 ### <a name='Unittesting'></a>Unittesting
 The plugin seed automatically adds Jasmine-based unittest support to your plugin.

--- a/demo/package.json
+++ b/demo/package.json
@@ -1,30 +1,30 @@
 {
-    "nativescript": {
-        "id": "org.nativescript.demo",
-        "tns-ios": {
-            "version": "3.0.1"
-        },
-        "tns-android": {
-            "version": "3.0.0"
-        }
+  "nativescript": {
+    "id": "org.nativescript.demo",
+    "tns-ios": {
+      "version": "3.1.0"
     },
-    "dependencies": {
-        "nativescript-theme-core": "^1.0.4",
-        "nativescript-unit-test-runner": "^0.3.4",
-        "nativescript-yourplugin": "../src",
-        "tns-core-modules": "^3.0.0"
-    },
-    "devDependencies": {
-        "babel-traverse": "6.12.0",
-        "babel-types": "6.11.1",
-        "babylon": "6.8.4",
-        "filewalker": "0.1.2",
-        "jasmine-core": "^2.5.2",
-        "karma": "^1.3.0",
-        "karma-jasmine": "^1.0.2",
-        "karma-nativescript-launcher": "^0.4.0",
-        "lazy": "1.0.11",
-        "nativescript-dev-typescript": "libs",
-        "typescript": "^2.2.2"
+    "tns-android": {
+      "version": "3.1.1"
     }
+  },
+  "dependencies": {
+    "nativescript-theme-core": "^1.0.4",
+    "nativescript-unit-test-runner": "^0.3.4",
+    "nativescript-yourplugin": "../src",
+    "tns-core-modules": "^3.1.0"
+  },
+  "devDependencies": {
+    "babel-traverse": "6.12.0",
+    "babel-types": "6.11.1",
+    "babylon": "6.8.4",
+    "filewalker": "0.1.2",
+    "jasmine-core": "^2.5.2",
+    "karma": "^1.3.0",
+    "karma-jasmine": "^1.0.2",
+    "karma-nativescript-launcher": "^0.4.0",
+    "lazy": "1.0.11",
+    "nativescript-dev-typescript": "libs",
+    "typescript": "~2.3.0"
+  }
 }

--- a/src/package.json
+++ b/src/package.json
@@ -19,11 +19,8 @@
         "plugin.link": "npm link && cd ../demo && npm link nativescript-yourplugin && cd ../src",
         "plugin.tscwatch": "npm run tsc -- -w",
         "demo.ios": "npm i && npm run tsc && cd ../demo && tns run ios --syncAllFiles",
-        "demo.android": "npm i && npm run tsc && cd ../demo && tns run android --syncAllFiles"
-    },
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/YourName/nativescript-yourplugin.git"
+        "demo.android": "npm i && npm run tsc && cd ../demo && tns run android --syncAllFiles",
+        "clean": "rm -rf node_modules && cd ../demo && rm -rf hooks node_modules platforms && cd ../src && npm run plugin.link"
     },
     "keywords": [
         "NativeScript",
@@ -45,9 +42,9 @@
         "tns-core-modules": "^3.0.0"
     },
     "devDependencies": {
-        "tns-core-modules": "^3.0.0",
-        "tns-platform-declarations": "^3.0.0",
-        "typescript": "^2.2.2",
+        "tns-core-modules": "^3.1.0",
+        "tns-platform-declarations": "^3.1.0",
+        "typescript": "~2.3.0",
         "prompt": "^1.0.0",
         "rimraf": "^2.5.0",
         "tslint": "^5.0.0"


### PR DESCRIPTION
* Seed was currently broken due to usage of `^` on `typescript` dep which was installing `2.4` which causes problems
* While fixing the above I went ahead and bumped the deps to latest
* A new command `npm run nuke` was added to help users clear plugin and demo files for a fresh install when needed