### PR TITLE
fix: show error if occurs on plugin build

### DIFF
--- a/src/scripts/prepare.js
+++ b/src/scripts/prepare.js
@@ -13,6 +13,12 @@ exec('tns --version', (err, stdout, stderr) => {
     // execute 'tns plugin build' for {N} version > 4. This command builds .aar in platforms/android folder.
     if (tnsVersion >= 4) {
         console.log(`executing 'tns plugin build'`);
-        exec('tns plugin build');
+        exec('tns plugin build', (err, stdout, stderr) => {
+            if (err) {
+                // node couldn't execute the command
+                console.log(`${err}`);
+                return;
+            }
+        });
     }
 });


### PR DESCRIPTION
current behavior: when you run `npm i`, `prepare` is also run which results in running `tns plugin build`. Currently if the command fails, the user is not notified.

updated behavior: if an error occurs during `npm plugin build`, error is shown.