### PR TITLE
Resolve issue with travis build for plugins after postclone is executed

### DIFF
--- a/src/.travis.yml
+++ b/src/.travis.yml
@@ -13,14 +13,14 @@ matrix:
       language: node_js 
       node_js: "8"
       jdk: oraclejdk8
-      script: cd demo && npm run build.plugin && npm i && tns build ios --bundle --env.uglify
+      script: cd src && npm run build && cd ../demo && npm i && tns build ios --bundle --env.uglify
     - language: android
       os: linux
       env:
         - WebPack="Android"
       jdk: oraclejdk8
       before_install: nvm install 8
-      script: cd demo && npm run build.plugin && npm i && tns build android --bundle --env.uglify --env.snapshot
+      script: cd src && npm run build && cd ../demo && npm i && tns build android --bundle --env.uglify --env.snapshot
     - language: android
       env: 
         - BuildAndroid="28"

--- a/src/package.json
+++ b/src/package.json
@@ -15,7 +15,7 @@
         "url": "https://github.com/YourName/nativescript-yourplugin.git"
     },
     "scripts": {
-        "tsc": "tsc",
+        "tsc": "npm i && tsc",
         "build": "npm run tsc && npm run build.native",
         "build.native": "node scripts/build-native.js",
         "postclone": "npm i && node scripts/postclone.js",


### PR DESCRIPTION

## PR Checklist

- [X] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [X] All existing tests are passing
- [ ] Tests for the changes are included

## What is the current behavior?
The travis build will fail because there is no longer `build.plugin` script in the demo application.

## What is the new behavior?
The travis build will execute correctly and build the plugin + the demo application.

Fixes/Implements/Closes #[Issue Number].
Also handles this issue: https://github.com/NativeScript/nativescript-plugin-seed/issues/130

