### PR TITLE
fix: remove not required predefined configuration from tsconfig

### DIFF
--- a/seed-tests/postclone.tests.js
+++ b/seed-tests/postclone.tests.js
@@ -62,8 +62,11 @@ describe('postclone', function () {
                     done.fail(error);
                 } else {
                     var seedCopyPath = path.resolve(__dirname, constants.SEED_COPY_LOCATION);
+                    let tsConfigContents = fs.readFileSync(seedCopyPath + "/demo/tsconfig.json").toString('utf-8');
+
                     expect(fs.existsSync(seedCopyPath + "/demo")).toBe(true);
                     expect(stdout.includes("Updating ../demo/")).toBe(true);
+                    expect(tsConfigContents.includes("app/*")).toBe(true);
 
                     expect(fs.existsSync(seedCopyPath + "/demo-angular")).toBe(false);
                     expect(stdout.includes("Updating ../demo-angular/")).toBe(false);
@@ -89,8 +92,11 @@ describe('postclone', function () {
                     expect(fs.existsSync(seedCopyPath + "/demo")).toBe(false);
                     expect(stdout.includes("Updating ../demo/")).toBe(false);
 
+                    let angularTsConfigContents = fs.readFileSync(seedCopyPath + "/demo-angular/tsconfig.json").toString('utf-8');
+
                     expect(fs.existsSync(seedCopyPath + "/demo-angular")).toBe(true);
                     expect(stdout.includes("Updating ../demo-angular/")).toBe(true);
+                    expect(angularTsConfigContents.includes("src/*")).toBe(true);
 
                     done();
                 }
@@ -110,9 +116,18 @@ describe('postclone', function () {
                     done.fail(error);
                 } else {
                     var seedCopyPath = path.resolve(__dirname, constants.SEED_COPY_LOCATION);
+                    let tsConfigContents = fs.readFileSync(seedCopyPath + "/demo/tsconfig.json").toString('utf-8');
+
                     expect(fs.existsSync(seedCopyPath + "/demo")).toBe(true);
+                    expect(stdout.includes("Updating ../demo/")).toBe(true);
+                    expect(tsConfigContents.includes("app/*")).toBe(true);
+
+                    let angularTsConfigContents = fs.readFileSync(seedCopyPath + "/demo-angular/tsconfig.json").toString('utf-8');
 
                     expect(fs.existsSync(seedCopyPath + "/demo-angular")).toBe(true);
+                    expect(stdout.includes("Updating ../demo-angular/")).toBe(true);
+                    expect(angularTsConfigContents.includes("src/*")).toBe(true);
+
                     done();
                 }
             });

--- a/src/scripts/postclone.js
+++ b/src/scripts/postclone.js
@@ -58,12 +58,6 @@ var class_name,
             value: [
                 "./node_modules/*"
             ]
-        },
-        {
-            key: "~/*",
-            value: [
-                "app/*"
-            ]
         }
     ],
     appNamePlaceholderStr = "appNamePlaceholder",


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [X] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [X] All existing tests are passing
- [X] Tests for the changes are included

## What is the current behavior?
After including an Angular demo from the postclone script that _demo-angular_ cannot run and throws webpack error during build time if you run it the new tns 5.4.0 workflow that uses `--bundle`

## What is the new behavior?
After including an Angular demo from the postclone script that _demo-angular_ runs correctly with the new tns 5.4.0 workflow that uses `--bundle`

Fixes/Implements/Closes #[Issue Number].
#140

