### PR TITLE
chore: remove the use of `--syncAllFiles` when calling tns commands

### DIFF
--- a/src/scripts/postclone.js
+++ b/src/scripts/postclone.js
@@ -69,11 +69,11 @@ var class_name,
     preDefinedAppScripts = [
         {
             key: "appNamePlaceholder.ios",
-            value: "npm run tsc && cd appPathPlaceholder && tns run ios --syncAllFiles --emulator"
+            value: "npm run tsc && cd appPathPlaceholder && tns run ios --emulator"
         },
         {
             key: "appNamePlaceholder.android",
-            value: "npm run tsc && cd appPathPlaceholder && tns run android --syncAllFiles --emulator"
+            value: "npm run tsc && cd appPathPlaceholder && tns run android --emulator"
         }],
     preDefinedPrepareScript =
     {


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [X] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [X] All existing tests are passing
- [ ] Tests for the changes are included

## What is the current behavior?
When executing one of the `demo.*` commands from the src package.json a message is shown:

> "--syncAllFiles" option has been deprecated and will be removed in the upcoming NativeScript CLI v6.0.0. More info can be found in this issue https://github.com/NativeScript/nativescript-cli/issues/4518.

## What is the new behavior?
When executing one of the `demo.*` commands from the src package.json no errors are shown and the app is started.

Fixes/Implements/Closes #[Issue Number].
https://github.com/orgs/NativeScript/projects/4#card-21900553
