### PR TITLE
Fix typo in reset portion of readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Sometimes you may need to wipe away the `src/node_modules`, `demo/node_modules` 
 
 Sometimes you just need to wipe out the demo's `platforms` directory only:
 
-* Run `npm run demo.reset` or `npm run demo-angular.ios` to delete the application's `platforms` directory only.
+* Run `npm run demo.reset` or `npm run demo-angular.reset` to delete the application's `platforms` directory only.
 
 Sometimes you may need to ensure plugin files are updated in the demo:
 


### PR DESCRIPTION
<!--
We, the rest of the NativeScript community, thank you for your
contribution! 
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [ ] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] All existing tests are passing
- [ ] Tests for the changes are included

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
There is a typo in the README.md located in the reset section.
## What is the new behavior?
<!-- Describe the changes. -->
changed demo-angular.ios -> demo-angular.reset in the README.md
Fixes/Implements/Closes #[Issue Number].

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

<!-- 
BREAKING CHANGES:
None

[Describe the impact of the changes here.]
The README.md is correct and users will use the correct reset command.
Migration steps:
[Provide a migration path for existing applications.]
-->

