### PR TITLE
fix build native script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ matrix:
         - NodeJs="8"
         - Type="TypeScript"
       language: android
+      dist: trusty
       os: linux
       jdk: oraclejdk8
       before_install: nvm install 8
@@ -39,6 +40,7 @@ matrix:
         - BuildAndroid="28"
         - Type="TypeScript"
       language: android
+      dist: trusty
       os: linux
       jdk: oraclejdk8
       before_install: nvm install 10
@@ -68,6 +70,7 @@ matrix:
         - BuildAndroid="28"
         - Type="Angular"
       language: android
+      dist: trusty
       jdk: oraclejdk8
       before_install: nvm install 10
       script:
@@ -93,6 +96,7 @@ matrix:
         - "curl -u $SAUCE_USER:$SAUCE_KEY -X POST -H 'Content-Type: application/octet-stream' $IOS_SAUCE_STORAGE/$IOS_PACKAGE_NG?overwrite=true --data-binary @$IOS_PACKAGE_FOLDER_NG/$IOS_PACKAGE_NG"
     - os: linux
       language: android
+      dist: trusty
       env:
         - UnitTests="Android"
         - TestVersion="latest"

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,20 @@ matrix:
       node_js: "10"
       script: cd src && npm run ci.tslint
     - stage: "Build and Test"
-      env: 
+      env:
+        - BuildAndroid="28"
+        - NodeJs="8"
+        - Type="TypeScript"
+      language: android
+      os: linux
+      jdk: oraclejdk8
+      before_install: nvm install 8
+      script:
+        - cd src && npm run postclone gitHubUsername=TheGitHubUser pluginName=ThePlugin initGit=y includeTypeScriptDemo=y includeAngularDemo=n
+        - npm run build
+        - cd ../demo
+        - tns build android
+    - env: 
         - BuildAndroid="28"
         - Type="TypeScript"
       language: android

--- a/src/scripts/build-native.js
+++ b/src/scripts/build-native.js
@@ -8,7 +8,15 @@ exec('tns --version', (err, stdout, stderr) => {
         return;
     }
 
-    const tnsVersion = semver.major(stdout);
+    // In case the current Node.js version is not supported by CLI, a warning in `tns --version` output is shown.
+    // Sample output:
+    //
+    /*Support for Node.js ^8.0.0 is deprecated and will be removed in one of the next releases of NativeScript. Please, upgrade to the latest Node.js LTS version.
+
+    6.0.0
+    */
+    // Extract the actual version (6.0.0) from it.
+    const tnsVersion = semver.major((stdout.match(/^(?:\d+\.){2}\d+.*?$/m) || [])[0]);
 
     // execute 'tns plugin build' for {N} version > 4. This command builds .aar in platforms/android folder.
     if (tnsVersion >= 4) {


### PR DESCRIPTION
fix: parse correctly CLI's version

In case the current Node.js version is not officialy supported by NativeScript CLI, i.e. its new and it is not verified or support for it is deprecated, `tns --version`'s output contains warning.
Extract the actual version from the output no matter if there's a warning or not.