### PR TITLE
Remove --emulator flags

### DIFF
--- a/src/scripts/postclone.js
+++ b/src/scripts/postclone.js
@@ -71,11 +71,11 @@ var class_name,
     preDefinedAppScripts = [
         {
             key: "appNamePlaceholder.ios",
-            value: "npm run tsc && cd appPathPlaceholder && tns run ios --emulator"
+            value: "npm run tsc && cd appPathPlaceholder && tns run ios"
         },
         {
             key: "appNamePlaceholder.android",
-            value: "npm run tsc && cd appPathPlaceholder && tns run android --emulator"
+            value: "npm run tsc && cd appPathPlaceholder && tns run android"
         }],
     preDefinedPrepareScript =
     {


### PR DESCRIPTION
## What is the current behavior?
Plugin demos executed with command `npm run demo.<ios:android>` are explicitly launch on an emulator, even if a "real" device is connected.

## What is the new behavior?
The demo will be launched on the emulator if no device is connected, else on the device.

Closes #171 

