### PR TITLE
chore: remove un-needed tsc in demo scripts

### DIFF
--- a/src/scripts/postclone.js
+++ b/src/scripts/postclone.js
@@ -71,11 +71,11 @@ var class_name,
     preDefinedAppScripts = [
         {
             key: "appNamePlaceholder.ios",
-            value: "cd appPathPlaceholder && tns run ios"
+            value: "npm i && cd appPathPlaceholder && tns run ios"
         },
         {
             key: "appNamePlaceholder.android",
-            value: "cd appPathPlaceholder && tns run android"
+            value: "npm i && cd appPathPlaceholder && tns run android"
         }],
     preDefinedPrepareScript =
     {

--- a/src/scripts/postclone.js
+++ b/src/scripts/postclone.js
@@ -71,11 +71,11 @@ var class_name,
     preDefinedAppScripts = [
         {
             key: "appNamePlaceholder.ios",
-            value: "npm run tsc && cd appPathPlaceholder && tns run ios"
+            value: "cd appPathPlaceholder && tns run ios"
         },
         {
             key: "appNamePlaceholder.android",
-            value: "npm run tsc && cd appPathPlaceholder && tns run android"
+            value: "cd appPathPlaceholder && tns run android"
         }],
     preDefinedPrepareScript =
     {


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/NativeScript/NativeScript/blob/master/CONTRIBUTING.md#commit-messages.
- [ ] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests are passing
- [ ] Tests for the changes are included

## What is the new behavior?
Remove unneeded `npm run tsc` when starting demo projects. Webpack builds the typescript.