### PR TITLE
Add information about the new plugin seed

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+# [OUTDATED]
+
+This is no longer the recommended way to start your plugin development. The new recommendation is to [use the all new plugin-seed](https://github.com/NativeScript/plugin-seed) workspace instead.
+
+
 # Develop a NativeScript plugin [![Build Status](https://travis-ci.org/NativeScript/nativescript-plugin-seed.svg?branch=master)](https://travis-ci.org/NativeScript/nativescript-plugin-seed)
 
 > This repo is heavily based on [@NathanWalker](https://github.com/NathanWalker)'s [Plugin Seed](https://github.com/NathanWalker/nativescript-plugin-seed). Thanks, Nathan!


### PR DESCRIPTION
When searching for the plugin seed I came to this repository first and started with the installation process.
From following the blog posts I know that there's a new way to seed plugins.

I'm not entirely sure if this repository really is outdated, but I thought it would make sense to add a note about the new repository here.